### PR TITLE
Bugfix in agency.txt, added support for frequencies.txt

### DIFF
--- a/src/Trafiklab/Gtfs/Model/Entities/Frequency.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/Frequency.php
@@ -1,0 +1,91 @@
+<?php
+
+
+namespace Trafiklab\Gtfs\Model\Entities;
+
+use DateTime;
+use Trafiklab\Gtfs\Model\GtfsArchive;
+
+class Frequency
+{
+    private $trip_id;
+    private $start_time;
+    private $end_time;
+    private $headway_secs;
+    private $exact_times;
+
+    private $archive;
+
+    /**
+     * Frequency constructor.
+     *
+     * @param GtfsArchive $archive The archive in which this data originates, used to link between files.
+     * @param array $data An associative array containing the variable values.
+     *
+     * @internal Not to be used outside of the Trafiklab\Gtfs\Model package.
+     */
+    function __construct(GtfsArchive $archive, array $data)
+    {
+        foreach ($data as $variable => $value) {
+            $this->$variable = $value;
+        }
+        $this->archive = $archive;
+    }
+
+    /**
+     * Identifies a trip to which the specified headway of service applies.
+     *
+     * @return string
+     */
+    public function getTripId(): string
+    {
+        return $this->trip_id;
+    }
+
+    /**
+     * Time at which the first vehicle departs from the first stop of the trip with the specified headway.
+     *
+     * @return DateTime
+     */
+    public function getStartTime(): DateTime
+    {
+        return DateTime::createFromFormat("H:i:s", $this->start_time);
+    }
+
+    /**
+     * Time at which service changes to a different headway (or ceases) at the first stop in the trip.
+     *
+     * @return DateTime
+     */
+    public function getEndTime(): DateTime
+    {
+        return DateTime::createFromFormat("H:i:s", $this->end_time);
+    }
+
+    /**
+     * Time, in seconds, between departures from the same stop (headway) for the trip, during the time 
+     * interval specified by start_time and end_time. Multiple headways for the same trip are allowed, 
+     * but may not overlap. New headways may start at the exact time the previous headway ends.
+     *
+     * @return int
+     */
+    public function getHeadwaySecs(): int
+    {
+        return $this->headway_secs;
+    }
+
+    /**
+     * Indicates the type of service for a trip. See the file description for more information. Valid options are:
+     * 
+     * 0 or empty - Frequency-based trips.
+     * 1 - Schedule-based trips with the exact same headway throughout the day. In this case the end_time value 
+     *     must be greater than the last desired trip start_time but less than the last desired trip 
+     *     start_time + headway_secs.
+     *
+     * @return int
+     */
+    public function getExactTimes(): int
+    {
+        return $this->exact_times;
+    }
+}

--- a/src/Trafiklab/Gtfs/Model/Entities/Route.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/Route.php
@@ -19,6 +19,8 @@ class Route
     private $route_color;
     private $route_text_color;
     private $route_sort_order;
+    private $continuous_pickup;
+    private $continuous_drop_off;
     private $archive;
 
     /**
@@ -170,5 +172,39 @@ class Route
     public function getRouteSortOrder(): ?int
     {
         return $this->route_sort_order;
+    }
+
+    /**
+     * Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path. The path is described by shapes.txt on every trip of the route. Valid options are:
+     *
+     * 0 - Continuous stopping pickup.
+     * 1 or empty - No continuous stopping pickup.
+     * 2 - Must phone an agency to arrange continuous stopping pickup.
+     * 3 - Must coordinate with a driver to arrange continuous stopping pickup.
+     *
+     * The default continuous pickup behavior defined in routes.txt can be overridden in stop_times.txt.
+     *
+     * @return int | null
+     */
+    public function getContinuousPickup(): ?int
+    {
+        return $this->continuous_pickup;
+    }
+
+    /**
+     * Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path. The path is described by shapes.txt on every trip of the route. Valid options are:
+     *
+     * 0- Continuous stopping drop-off.
+     * 1 or empty - No continuous stopping drop-off.
+     * 2 - Must phone an agency to arrange continuous stopping drop-off.
+     * 3 - Must coordinate with a driver to arrange continuous stopping drop-off.
+     * 
+     * The default continuous drop-off behavior defined in routes.txt can be overridden in stop_times.txt.
+     *
+     * @return int | null
+     */
+    public function getContinuousDropOff(): ?int
+    {
+        return $this->continuous_drop_off;
     }
 }

--- a/src/Trafiklab/Gtfs/Model/Entities/ShapePoint.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/ShapePoint.php
@@ -88,6 +88,6 @@ class ShapePoint
      */
     public function getShapeDistTraveled(): ?float
     {
-        return $this->shape_dist_traveled;
+        return ((string) $this->shape_dist_traveled) != '' ? $this->shape_dist_traveled : null;
     }
 }

--- a/src/Trafiklab/Gtfs/Model/Entities/Stop.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/Stop.php
@@ -20,6 +20,7 @@ class Stop
     private $parent_station;
     private $stop_timezone;
     private $wheelchair_boarding;
+    private $level_id;
     private $platform_code;
 
     private $archive;
@@ -224,7 +225,7 @@ class Stop
      */
     public function getLocationType(): ?int
     {
-        if ($this->location_type == null){
+        if ($this->location_type == null) {
             return null;
         }
         return intval($this->location_type);
@@ -257,5 +258,15 @@ class Stop
     public function getWheelchairBoarding(): int
     {
         return $this->wheelchair_boarding;
+    }
+
+    /**
+     * Level of the location. The same level can be used by multiple unlinked stations.
+     *
+     * @return string | null
+     */
+    public function getLevelId(): ?string
+    {
+        return $this->level_id;
     }
 }

--- a/src/Trafiklab/Gtfs/Model/Entities/Stop.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/Stop.php
@@ -255,7 +255,7 @@ class Stop
      *
      * @return int | null
      */
-    public function getWheelchairBoarding(): int
+    public function getWheelchairBoarding(): ?int
     {
         return $this->wheelchair_boarding;
     }

--- a/src/Trafiklab/Gtfs/Model/Entities/StopTime.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/StopTime.php
@@ -176,7 +176,7 @@ class StopTime
      */
     public function getShapeDistTraveled(): ?float
     {
-        return $this->shape_dist_traveled;
+        return ((string) $this->shape_dist_traveled) != '' ? $this->shape_dist_traveled : null;
     }
 
     /**

--- a/src/Trafiklab/Gtfs/Model/Entities/StopTime.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/StopTime.php
@@ -19,6 +19,8 @@ class StopTime
     private $drop_off_type;
     private $shape_dist_traveled;
     private $timepoint;
+    private $continuous_pickup;
+    private $continuous_drop_off;
     private $archive;
 
     /**
@@ -198,5 +200,38 @@ class StopTime
     public function getTimepoint(): ?int
     {
         return $this->timepoint;
+    }
+
+    /**
+     * Indicates whether a rider can board the transit vehicle at any point along the vehicle’s travel path. The path is described by shapes.txt, from this stop_time to the next stop_time in the trip’s stop_sequence. Valid options are:
+     * 
+     * 0 - Continuous stopping pickup.
+     * 1 or empty - No continuous stopping pickup.
+     * 2 - Must phone an agency to arrange continuous pickup.
+     * 3 - Must coordinate with a driver to arrange continuous stopping pickup.
+     * 
+     * The continuous pickup behavior indicated in stop_times.txt overrides any behavior defined in routes.txt.
+     * 
+     * @return int|null
+     */
+    public function getContinuousPickup(): ?int
+    {
+        return $this->continuous_pickup;
+    }
+
+    /**
+     * Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path as described by shapes.txt, from this stop_time to the next stop_time in the trip’s stop_sequence.
+     * 
+     * 0 - Continuous stopping drop off.
+     * 1 or empty - No continuous stopping drop off.
+     * 2 - Must phone an agency to arrange continuous drop off.
+     * 3 - Must coordinate with a driver to arrange continuous stopping drop off.
+     * 
+     * The continuous drop-off behavior indicated in stop_times.txt overrides any behavior defined in routes.txt.
+     * @return int|null
+     */
+    public function getContinuousDropOff(): ?int
+    {
+        return $this->continuous_drop_off;
     }
 }

--- a/src/Trafiklab/Gtfs/Model/Files/GtfsAgencyFile.php
+++ b/src/Trafiklab/Gtfs/Model/Files/GtfsAgencyFile.php
@@ -13,8 +13,11 @@ class GtfsAgencyFile
 
     public function __construct(GtfsArchive $parent, string $filePath)
     {
-        $this->dataRows = GtfsParserUtil::deserializeCSV($parent, $filePath,
-            Agency::class, 'trip_id');
+        $this->dataRows = GtfsParserUtil::deserializeCSV(
+            $parent,
+            $filePath,
+            Agency::class
+        );
     }
 
     /**

--- a/src/Trafiklab/Gtfs/Model/Files/GtfsFrequenciesFile.php
+++ b/src/Trafiklab/Gtfs/Model/Files/GtfsFrequenciesFile.php
@@ -3,7 +3,7 @@
 namespace Trafiklab\Gtfs\Model\Files;
 
 
-use Trafiklab\Gtfs\Model\Entities\FeedInfo;
+use Trafiklab\Gtfs\Model\Entities\Frequency;
 use Trafiklab\Gtfs\Model\GtfsArchive;
 use Trafiklab\Gtfs\Util\Internal\GtfsParserUtil;
 

--- a/src/Trafiklab/Gtfs/Model/Files/GtfsFrequenciesFile.php
+++ b/src/Trafiklab/Gtfs/Model/Files/GtfsFrequenciesFile.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Trafiklab\Gtfs\Model\Files;
+
+
+use Trafiklab\Gtfs\Model\Entities\FeedInfo;
+use Trafiklab\Gtfs\Model\GtfsArchive;
+use Trafiklab\Gtfs\Util\Internal\GtfsParserUtil;
+
+class GtfsFrequenciesFile
+{
+    private $dataRows;
+
+    public function __construct(GtfsArchive $parent, string $filePath)
+    {
+        $this->dataRows = GtfsParserUtil::deserializeCSV(
+            $parent,
+            $filePath,
+            Frequency::class
+        );
+    }
+
+    /**
+     * Get the file data as an array of its rows.
+     *
+     * @return Frequency[]
+     */
+    public function getFrequencies(): array
+    {
+        return $this->dataRows;
+    }
+}

--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -198,7 +198,7 @@ class GtfsArchive
     /**
      * @return GtfsFrequenciesFile
      */
-    public function getFrequenciesFile(): GtfsTripsFile
+    public function getFrequenciesFile(): GtfsFrequenciesFile
     {
         return $this->loadGtfsFileThroughCache(__METHOD__, self::TRIPS_TXT, GtfsFrequenciesFile::class);
     }

--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -9,6 +9,7 @@ use Trafiklab\Gtfs\Model\Files\GtfsAgencyFile;
 use Trafiklab\Gtfs\Model\Files\GtfsCalendarDatesFile;
 use Trafiklab\Gtfs\Model\Files\GtfsCalendarFile;
 use Trafiklab\Gtfs\Model\Files\GtfsFeedInfoFile;
+use Trafiklab\Gtfs\Model\Files\GtfsFrequenciesFile;
 use Trafiklab\Gtfs\Model\Files\GtfsRoutesFile;
 use Trafiklab\Gtfs\Model\Files\GtfsShapesFile;
 use Trafiklab\Gtfs\Model\Files\GtfsStopsFile;
@@ -192,6 +193,14 @@ class GtfsArchive
     public function getTripsFile(): GtfsTripsFile
     {
         return $this->loadGtfsFileThroughCache(__METHOD__, self::TRIPS_TXT, GtfsTripsFile::class);
+    }
+
+    /**
+     * @return GtfsFrequenciesFile
+     */
+    public function getFrequenciesFile(): GtfsTripsFile
+    {
+        return $this->loadGtfsFileThroughCache(__METHOD__, self::TRIPS_TXT, GtfsFrequenciesFile::class);
     }
 
     /**

--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -200,7 +200,7 @@ class GtfsArchive
      */
     public function getFrequenciesFile(): GtfsFrequenciesFile
     {
-        return $this->loadGtfsFileThroughCache(__METHOD__, self::TRIPS_TXT, GtfsFrequenciesFile::class);
+        return $this->loadGtfsFileThroughCache(__METHOD__, self::FREQUENCIES_TXT, GtfsFrequenciesFile::class);
     }
 
     /**


### PR DESCRIPTION
In agency.txt the agency_id is conditionally required. This means that the import will fail if the agency_id is required as key in the code but not present in the file. This PR solves it.