### PR TITLE
If modified since feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,43 @@ $gtfsArchive = GtfsArchive::createFromPath("gtfs.zip");
 $gtfsArchive = GtfsArchive::createFromUrl("http://example.com/gtfs.zip");
 ```
 
+Optionally, you can choose to download a GTFS zip file only if it has changed since the last retrieval. This is useful when trying to automate GTFS retrievals that need to be stored within a database, without constantly rewriting the same data each time.
+The following Http Headers are used:
+
+ - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
+ - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
+ - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+
+Most agencies provide a Last-Modified header, but if it's not present, ETag is the best route to go. If for some reason ETag is also not provided, it will just continue normally as if you were to use the original GtfsArchive::createFromUrl() method.
+
+```php
+ $gtfsArchive = GtfsArchive::createFromUrlIfModified(
+    "http://example.com/gtfs.zip",
+    "Wed, 10 Jun 2020 15:56:14 GMT",
+    "99fa-5a7bce236c526"
+ );
+```
+
+If you don't have an ETag or Last-Modified value to begin with, simply leave them out and the method will retrieve them for you.
+
+```php
+ if ($gtfsArchive = GtfsArchive::createFromUrlIfModified("http://example.com/gtfs.zip") {
+    // Get Methods return null if GTFS Url does not contain the specified Header: ETag, Last-Modified.
+    $lastModified = $gtfsArchive->getLastModified(); // Wed, 10 Jun 2020 15:56:14 GMT | null
+    $eTag         = $gtfsArchive->getETag(); // "99fa-5a7bce236c526" | null
+    
+    // You can get the Last-Modified datetime PHP Object (Useful for storing in databases) by doing the following:
+    $datetime = $gtfsArchive->getLastModifiedDateTime() // DateTime Object | null
+    
+    // Or Convert it back to a String using the standard Last-Modified HTTP header format.
+    if ($datetime) {
+      $lastModified = GtfsArchive::getLastModifiedFromDateTime($datetime); // Wed, 10 Jun 2020 15:56:14 GMT
+    }  
+ }
+ 
+```
+
+
 Files are extracted to a temporary directory (/tmp/gtfs/), and cleaned up when the GtfsArchive object is destructed.
 You can call `$gtfsArchive->deleteUncompressedFiles()` to manually remove the uncompressed files. 
 

--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -340,18 +340,23 @@ class GtfsArchive
         return $this->getCachedResult($method);
     }
 
-    private static function parseHeaders( array $headers ): array
+    /**
+     * Parse file_get_contents Response headers into an array
+     * Primarily to retrieve the Status Code, Last-Modified, and ETag headers.
+     * @param array $headers
+     * @return array
+     */
+    private static function parseHeaders(array $headers): array
     {
         $headersArray = [];
-        foreach( $headers as $k => $v )
-        {
-            $t = explode( ':', $v, 2 );
-            if( isset( $t[1] ) )
+        foreach($headers as $k => $v) {
+            $t = explode(':', $v, 2);
+            if (isset($t[1])) {
                 $headersArray[ trim($t[0]) ] = trim( $t[1] );
-            else
-            {
+            }
+            else {
                 $headersArray[] = $v;
-                if( preg_match( "#HTTP/[0-9\.]+\s+([0-9]+)#",$v, $out ) )
+                if (preg_match("#HTTP/[0-9\.]+\s+([0-9]+)#", $v, $out) )
                     $headersArray['Status'] = intval($out[1]);
             }
         }

--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -43,6 +43,13 @@ class GtfsArchive
 
     private $fileRoot;
 
+    /** @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified */
+    private const LAST_MODIFIED_FORMAT = "D, d M Y H:i:s e";
+    /** @var null|string $archiveLastModified */
+    private static $archiveLastModified = null;
+    /** @var null|string $archiveETag */
+    private static $archiveETag = null;
+
     private function __construct(string $fileRoot)
     {
         $this->fileRoot = $fileRoot;
@@ -61,6 +68,97 @@ class GtfsArchive
         $downloadedArchive = self::downloadFile($url);
         $fileRoot = self::extractFiles($downloadedArchive, true);
         return new GtfsArchive($fileRoot);
+    }
+
+    /**
+     * Creates the context and returns it for use in file_get_contents
+     * Adds the If-Modified-Since header to check if the GTFS has been modified.
+     */
+    private static function createRequestContext(?\DateTime $lastModified = null)
+    {
+        /** @var string $lastModifiedString */
+        self::$archiveLastModified = $lastModified !== null ? self::getLastModifiedFromDateTime($lastModified) : '';
+        return stream_context_create([
+            'http' => [
+                'header' => "If-Modified-Since: " . self::$archiveLastModified,
+                'method'        => 'GET',
+                'ignore_errors' => true
+            ],
+        ]);
+    }
+
+    /**
+     * Only create a new Archive if it has been modified since the last PULL
+     * We delete the Zip archive after each cycle as this is meant to constantly check headers.
+     * @param string $url
+     * @param \DateTime|null $lastModified
+     * @param string|null $eTag
+     * @return GtfsArchive|null
+     * @throws Exception
+     */
+    public static function createFromUrlIfModified(
+        string $url,
+        ?\DateTime $lastModified = null,
+        ?string $eTag = null
+    ): ?GtfsArchive {
+        $temp_file = self::TEMP_ROOT . md5($url) . ".zip";
+        if (!file_exists($temp_file)) {
+            try {
+                /** Create the Request Context (Returns Stream Context) */
+                $context = self::createRequestContext($lastModified);
+
+                /** Download the zip file if it's been modified, or exists. */
+                file_put_contents($temp_file, file_get_contents($url, false, $context));
+
+                /**
+                 * @var array $http_response_header materializes out of thin air unfortunately
+                 * Parse the headers so we can retrieve what we need.
+                 */
+                $responseHeaders = self::parseHeaders($http_response_header);
+
+                /** @var integer $statusCode
+                 * Track the Status code to determine if the file has changed, or exists.
+                 */
+                $statusCode = $responseHeaders['Status'];
+
+                switch ($statusCode) {
+                    case 200:
+                        /**
+                         * If the Status Code is 200, that means the file has been modified or it is a new GTFS Source.
+                         * Track the eTag and Last-Modified headers if they exist.
+                         */
+                        self::$archiveLastModified = $responseHeaders['Last-Modified'] ?? null;
+                        self::$archiveETag = $responseHeaders['ETag'] ?? null;
+
+                        /** If no last-modified date is present, and Etag is present and matches, skip as it's not modified */
+                        if ($eTag !== null && self::$archiveETag !== null && $eTag == self::$archiveETag) {
+                            return null;
+                        } else {
+                            /**
+                             * Last-Modified Date wasn't present, and eTag is not present or didn't match.
+                             * Extract files and return the GtfsArchive.
+                             */
+                            $fileRoot = self::extractFiles($temp_file, true);
+                            return new GtfsArchive($fileRoot);
+                        }
+                    case 304:
+                        /**  304 = NOT_MODIFIED (This file hasn't changed since the last pull) */
+                        self::$archiveETag = $eTag;
+                        break;
+                    default:
+                        /** Status Code returned a 400 error or similar meaning the URL is invalid or down. */
+                        throw new Exception("Could not open the GTFS archive, Status Code: {$statusCode}");
+                }
+            } catch (Exception $exception) {
+                throw new Exception(
+                    "There was an issue downloading the GTFS from the requested URL: {$url}, Error: {$exception->getMessage()}"
+                );
+            } finally {
+                /** Clean up - Delete the Downloaded Zip if it exists. */
+                self::deleteArchive($temp_file);
+            }
+        }
+        return null;
     }
 
     /**
@@ -96,6 +194,9 @@ class GtfsArchive
         return $temp_file;
     }
 
+    /**
+     * @throws Exception
+     */
     private static function extractFiles(string $archiveFilePath, bool $deleteArchive = false)
     {
         // Load the zip file.
@@ -109,7 +210,7 @@ class GtfsArchive
         $zip->close();
 
         if ($deleteArchive) {
-            unlink($archiveFilePath);
+            self::deleteArchive($archiveFilePath);
         }
 
         return $extractionPath;
@@ -224,11 +325,81 @@ class GtfsArchive
         rmdir($this->fileRoot);
     }
 
+    private static function deleteArchive(string $archiveFilePath)
+    {
+        if (file_exists($archiveFilePath)) {
+            unlink($archiveFilePath);
+        }
+    }
+
     private function loadGtfsFileThroughCache(string $method, string $file, string $class)
     {
         if ($this->getCachedResult($method) == null) {
             $this->setCachedResult($method, new $class($this, $this->fileRoot . $file));
         }
         return $this->getCachedResult($method);
+    }
+
+    private static function parseHeaders( array $headers ): array
+    {
+        $headersArray = [];
+        foreach( $headers as $k => $v )
+        {
+            $t = explode( ':', $v, 2 );
+            if( isset( $t[1] ) )
+                $headersArray[ trim($t[0]) ] = trim( $t[1] );
+            else
+            {
+                $headersArray[] = $v;
+                if( preg_match( "#HTTP/[0-9\.]+\s+([0-9]+)#",$v, $out ) )
+                    $headersArray['Status'] = intval($out[1]);
+            }
+        }
+        return $headersArray;
+    }
+
+    /**
+     * Return the DateTime Object for the Last Modified Date
+     * Useful for storing in databases, etc.
+     * @return \DateTime|null
+     * @throws Exception
+     */
+    public function getLastModifiedDateTime(): ?\DateTime
+    {
+        $datetime = (
+            new \DateTime(
+                self::$archiveLastModified,
+                new \DateTimeZone('GMT')
+            )
+        );
+        return self::$archiveLastModified !== null ? $datetime : null;
+    }
+
+    /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
+     * @param \DateTime $dateTime
+     * @return string
+     */
+    public static function getLastModifiedFromDateTime(\DateTime $dateTime): string
+    {
+        return $dateTime
+            ->setTimezone(new \DateTimeZone('GMT'))
+            ->format(self::LAST_MODIFIED_FORMAT);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getArchiveLastModified(): ?string
+    {
+        return self::$archiveLastModified ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getArchiveETag(): ?string
+    {
+        return self::$archiveETag ?? null;
     }
 }


### PR DESCRIPTION
The purpose of this pull-request is primarily to solve the issue of systems that need to store GTFS tables within a database or other form of datastore. Since some GTFS files can be large, require a lot of processing power, and typically go unchanged for months, we need a way to determine if a GTFS feed has changed since the last time we checked.

Most systems typically check daily for GTFS changes if they want the process to be automated, by using the following headers:

 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified (Last-Modified)
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since (If-Modified-Since)
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag (ETag)

We are able to determine if the file we are pulling hasn't changed since the last time we processed the data, saving us tons of resources, and allowing us to simply skip the "import" until the next time the file changes.

### Change Log:

- Added Helper methods for formatting and converting Last-Modified headers to the standard string format, and also as PHP DateTime Objects for storing in databases.
- Used the original file_get_contents method and added $context to check for Status Codes and the mentioned headers, to avoid importing new libraries or bloating the original package.
- Added examples on how to use the Methods to the readme.
- Using the createFromUrlIfModified() method will return a GTFSArchive if changes are detected, or null if there has been no changes to simplify checks on whether to skip database creation or to continue.
- Created a deleteArchive() method to reduce duplicated code.
