### PR TITLE
Delete uncompressed files even when directory is present

### DIFF
--- a/src/Trafiklab/Gtfs/Model/GtfsArchive.php
+++ b/src/Trafiklab/Gtfs/Model/GtfsArchive.php
@@ -168,7 +168,7 @@ class GtfsArchive
             } catch (Exception $exception) {
                 throw new Exception(
                     "There was an issue downloading the GTFS from the requested URL: {$url}, Error: " .
-                    $exception->getMessage()
+                    $exception->getMessage(), $statusCode ?? 0
                 );
             } finally {
                 /** Clean up - Delete the Downloaded Zip if it exists. */
@@ -333,8 +333,15 @@ class GtfsArchive
         $files = scandir($this->fileRoot);
         foreach ($files as $file) {
             if ($file != '.' && $file != '..') {
-                // Remove all extracted files from the zip file.
-                unlink($this->fileRoot . '/' . $file);
+                $path = $this->fileRoot . DIRECTORY_SEPARATOR . $file;
+                /** Check for OS Specific directories that could've been added. Ex: _MACOSX/ */
+                if (is_dir($path)) {
+                    rmdir($path);
+                } else {
+                    // Remove all extracted files from the zip file.
+                    unlink($path);
+                }
+
             }
         }
         reset($files);


### PR DESCRIPTION
On systems like Windows or Mac OS, during unzipping of the GTFS feed, folders could be created such as _MACOSX which causes the deleteUncompressedFiles() method to fail. This is fixed simply by checking within the file loop if the "file" is actually a file or a directory.

Simply rmdir() or unlink() depending on the result.

Also adjusted the createFromUrlIfModified() method to return the status code if it exists, which could be helpful for determining if the URL is not found (404), when handling errors.