### PR TITLE
Agency Id can be null

### DIFF
--- a/src/Trafiklab/Gtfs/Model/Entities/Agency.php
+++ b/src/Trafiklab/Gtfs/Model/Entities/Agency.php
@@ -46,7 +46,7 @@ class Agency
      *
      * @return string
      */
-    public function getAgencyId(): string
+    public function getAgencyId(): ?string
     {
         return $this->agency_id;
     }


### PR DESCRIPTION
Agency id is "Conditionally Required" and it can be `null`.

https://developers.google.com/transit/gtfs/reference#agencytxt